### PR TITLE
Revert "main: import app from app module instead of index"

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-from frontend.app import app
+from frontend.index import app
 
 if __name__ == "__main__":
     app.run_server(host='0.0.0.0', port=8050, debug=False)


### PR DESCRIPTION
This reverts commit 47f70ac3127dcc01e3a585e834b0bd5b829543c2.

The app must be imported always after the layout is added to the dash app.
In other case it retruns 500 error